### PR TITLE
QR8bitByte: fix utf-8 encoding

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "react-redux": "^7.2.0",
     "react-scripts": "3.4.1",
     "redux": "^4.0.5",
-    "serialize-javascript": "^3.1.0"
+    "serialize-javascript": "^3.1.0",
+    "utf8": "^3.0.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/utils/qrcodeEncoder.js
+++ b/src/utils/qrcodeEncoder.js
@@ -13,42 +13,18 @@
 //   http://www.denso-wave.com/qrcode/faqpatent-e.html
 //
 //---------------------------------------------------------------------
+const utf8 = require('utf8');
+
 /* eslint-disable */
 function QR8bitByte(data) {
     this.mode = QRMode.MODE_8BIT_BYTE;
-    this.data = data;
+    this.data = utf8.encode(data);
     this.parsedData = [];
 
     // Added to support UTF-8 Characters
     for (var i = 0, l = this.data.length; i < l; i++) {
-        var byteArray = [];
         var code = this.data.charCodeAt(i);
-
-        if (code > 0x10000) {
-            byteArray[0] = 0xF0 | ((code & 0x1C0000) >>> 18);
-            byteArray[1] = 0x80 | ((code & 0x3F000) >>> 12);
-            byteArray[2] = 0x80 | ((code & 0xFC0) >>> 6);
-            byteArray[3] = 0x80 | (code & 0x3F);
-        } else if (code > 0x800) {
-            byteArray[0] = 0xE0 | ((code & 0xF000) >>> 12);
-            byteArray[1] = 0x80 | ((code & 0xFC0) >>> 6);
-            byteArray[2] = 0x80 | (code & 0x3F);
-        } else if (code > 0x80) {
-            byteArray[0] = 0xC0 | ((code & 0x7C0) >>> 6);
-            byteArray[1] = 0x80 | (code & 0x3F);
-        } else {
-            byteArray[0] = code;
-        }
-
-        this.parsedData.push(byteArray);
-    }
-
-    this.parsedData = Array.prototype.concat.apply([], this.parsedData);
-
-    if (this.parsedData.length != this.data.length) {
-        this.parsedData.unshift(191);
-        this.parsedData.unshift(187);
-        this.parsedData.unshift(239);
+        this.parsedData.push(code);
     }
 }
 


### PR DESCRIPTION
See #41 
input strings with unicode characters at high code points were not encoded correctly, such as "🔝"